### PR TITLE
changes for log analytics - b2ctestcaserunner changes

### DIFF
--- a/b2ctestcaserunner/Log_Query.txt
+++ b/b2ctestcaserunner/Log_Query.txt
@@ -1,0 +1,61 @@
+// To find the test started, completed, failed count
+customEvents
+| extend guid = tostring(customDimensions.correlationId)
+| extend parentguid = tostring(customDimensions.batchCorrelationId)
+| join kind=inner (
+    customEvents
+    | where name like 'starting with the test suite'
+    | sort by timestamp desc 
+    | extend parentguid = tostring(customDimensions.correlationId)
+    | limit 1
+) on  parentguid
+| where name like 'Test Started' or name like 'Test Failure' or name like 'Test Completed'
+| summarize count1=dcount(guid) by guid,name
+| summarize Total = sum(count1) by Result=name
+
+// To find the test failed guid 
+customEvents
+| extend guid = tostring(customDimensions.correlationId)
+| extend parentguid = tostring(customDimensions.batchCorrelationId)
+| join kind=inner (
+    customEvents
+    | where name like 'starting with the test suite'
+    | sort by timestamp desc 
+    | extend parentguid = tostring(customDimensions.correlationId)
+    | limit 1
+) on  parentguid
+| where name like 'Test Failure'// or name like 'Test Failure' or name like 'TestCaseComplete'
+| summarize Total=dcount(guid) by Guid=guid,Result=name
+
+
+// To find the time taken metrics
+ customEvents
+| extend guid = tostring(customDimensions.correlationId)
+| extend parentguid = tostring(customDimensions.batchCorrelationId)
+| join kind=inner (
+    customEvents
+    | where name like 'starting with the test suite'
+    | sort by timestamp desc 
+    | extend parentguid = tostring(customDimensions.correlationId)
+    | limit 1
+) on  parentguid
+| where name like 'Test Completed'
+| extend duration = tolong(customDimensions.duration)
+| summarize MaxTime = max(duration), MinTime = min(duration), Average = avg(duration), Median = percentile(duration,50)
+
+
+
+// To find the time taken metrics per navigation
+customEvents
+| extend guid = tostring(customDimensions.correlationId)
+| extend parentguid = tostring(customDimensions.batchCorrelationId)
+| extend duration = tolong(customDimensions.duration)
+| join kind=inner (
+    customEvents
+    | where name like 'starting with the test suite'
+    | sort by timestamp desc 
+    | extend parentguid = tostring(customDimensions.correlationId)
+    | limit 1
+) on  parentguid
+| where name like 'Navigation' 
+| summarize MaxTime = max(duration), MinTime = min(duration), Average = avg(duration), Median = percentile(duration,50)

--- a/b2ctestcaserunner/Program.cs
+++ b/b2ctestcaserunner/Program.cs
@@ -15,14 +15,18 @@ namespace b2ctestcaserunner
             {
                 string containerName = "";
                 string consoleLogFile = "";
-                List<string> argList = ParseArgs(args, ref containerName, ref consoleLogFile);
+				string parentCorrelationId = "";
+                List<string> argList = ParseArgs(args, ref containerName, ref consoleLogFile, ref parentCorrelationId);
                 if (!string.IsNullOrEmpty(consoleLogFile))
                     TelemetryLog.consoleFile = consoleLogFile;
 
+                if (string.IsNullOrEmpty(parentCorrelationId))
+                  parentCorrelationId = Guid.NewGuid().ToString(); 
+
                 foreach (string arg in argList)
                 {
-                    TestCase testCase = new TestCase(args[0], containerName);
-
+                    Guid id = Guid.NewGuid();
+                    TestCase testCase = new TestCase(args[0], containerName,id.ToString(),parentCorrelationId);
                     testCase.DoTests();
                 }
             }
@@ -41,10 +45,12 @@ namespace b2ctestcaserunner
         }
 
 
-        static List<string> ParseArgs(string[] args, ref string containerName, ref string logFile)
+
+        static List<string> ParseArgs(string[] args, ref string containerName, ref string logFile, ref string parentCorrelationId)
         {
             containerName = args.Where(a => a.ToLower().Contains("container:")).FirstOrDefault();
             logFile = args.Where(a => a.ToLower().Contains("logfile:")).FirstOrDefault();
+            parentCorrelationId = args.Where(a => a.ToLower().Contains("parentCorrelationId:")).FirstOrDefault();
 
             List<string> argList = args.ToList();
 
@@ -66,6 +72,16 @@ namespace b2ctestcaserunner
             {
                 argList.Remove(logFile);
                 logFile = logFile.Substring(logFile.IndexOf(":") + 1);
+            }
+
+            if (string.IsNullOrEmpty(parentCorrelationId))
+            {
+                parentCorrelationId = "";
+            }
+            else
+            {
+                argList.Remove(parentCorrelationId);
+                parentCorrelationId = parentCorrelationId.Substring(parentCorrelationId.IndexOf(":") + 1);
             }
             return argList;
         }


### PR DESCRIPTION
In this PR, added the changes for 
1. Log lines with event properties like correlationId, parent correlationId, duration wherever necessary
2. Added support to accept the parentcorrelationId from cmd line,
3. Log analytics queries (log_query.txt file) 
